### PR TITLE
Remove webext-ublock-origin from packages

### DIFF
--- a/include/packages-phosh.yaml
+++ b/include/packages-phosh.yaml
@@ -27,7 +27,7 @@ actions:
       - gnome-weather
       - lollypop
       - portfolio-filemanager
-      - webext-ublock-origin
+      - webext-ublock-origin-firefox
 
   - action: run
     description: Disable getty in the Phosh environment


### PR DESCRIPTION
2023/01/03 13:39:30 apt | Package webext-ublock-origin is not available, but is referred to by another package. 2023/01/03 13:39:30 apt | This may mean that the package is missing, has been obsoleted, or 2023/01/03 13:39:30 apt | is only available from another source 2023/01/03 13:39:30 apt | However the following packages replace it:
2023/01/03 13:39:30 apt |   webext-ublock-origin-firefox webext-ublock-origin-chromium
2023/01/03 13:39:30 apt | 
2023/01/03 13:39:30 apt | E: Package 'webext-ublock-origin' has no installation candidate
2023/01/03 13:39:30 Action `recipe` failed at stage Run, error: exit status 100

webext-ublock-origin it split into two different packages firefox-esr is in the package lists. it should either be removed or webext-ublock-origin-firefox be added