### PR TITLE
add wget and libsdl2-ttf-2.0-0 to packages to install in chroot

### DIFF
--- a/devices/nexus-5/get-tweaks.sh
+++ b/devices/nexus-5/get-tweaks.sh
@@ -1,4 +1,4 @@
 cd &&
 wget https://gitlab.com/iih09276/nexus-5-repo/-/raw/main/rootfs.7z && cd / &&
-7z x /root/rootfs.7z -y && cd && uname -r && 
+7z x /root/rootfs.7z -y && cd && uname -r &&
 ./setup.sh

--- a/devices/nexus-5/packages-phosh.yaml
+++ b/devices/nexus-5/packages-phosh.yaml
@@ -17,3 +17,4 @@ actions:
       - qrtr
       - rmtfs
       - wget
+      - libsdl2-ttf-2.0-0

--- a/devices/nexus-5/packages-phosh.yaml
+++ b/devices/nexus-5/packages-phosh.yaml
@@ -16,3 +16,4 @@ actions:
       - p7zip-full
       - qrtr
       - rmtfs
+      - wget


### PR DESCRIPTION
wget is required by get-tweaks.sh script (bootloader.yaml: Get kernel and prepare has chroot: true) inside the chroot but it is not installed by default and build will fail at this point
libsdl2-ttf-2.0-0 is required by charging-sdl as a dependency and must be installed inside the chroot